### PR TITLE
Run Jekyll build on Windows

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   # Build job
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -10,6 +10,7 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["master"]
+  pull_request:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -54,6 +55,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: "github.ref == master"
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
To fix the error:

You are trying to install in deployment mode after changing your Gemfile. Run `bundle install` elsewhere and add the updated Gemfile.lock to version control.

If this is a development machine, remove the
/home/runner/work/personal-website/personal-website/Gemfile freeze by running `bundle config unset deployment`.

You have deleted from the Gemfile:
* wdm (>= 0.1.0)