### PR TITLE
Install faraday-retry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,10 @@
 source 'https://rubygems.org'
-gem 'jekyll'
-gem "jekyll-github-metadata"
-gem "jekyll-octicons"
-
-gem 'wdm', '>= 0.2.0' if Gem.win_platform?
 
 gem "dotenv", "~> 2.7"
-
+gem "jekyll-github-metadata"
+gem "jekyll-octicons"
 gem "jekyll-org", git: "https://github.com/eggcaker/jekyll-org.git"
-
+gem 'faraday-retry'
+gem 'jekyll'
+gem 'wdm', '>= 0.2.0' if Gem.win_platform?
 gem 'word_wrap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,8 @@ GEM
       logger
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
+    faraday-retry (2.3.2)
+      faraday (~> 2.0)
     ffi (1.17.2-x64-mingw-ucrt)
     forwardable-extended (2.6.0)
     google-protobuf (4.32.0-x64-mingw-ucrt)
@@ -113,6 +115,7 @@ PLATFORMS
 
 DEPENDENCIES
   dotenv (~> 2.7)
+  faraday-retry
   jekyll
   jekyll-github-metadata
   jekyll-octicons


### PR DESCRIPTION
"To use retry middleware with Faraday v2.0+, install faraday-retry gem"

https://github.com/octokit/octokit.rb/discussions/1486