### PR TITLE
Depend on fiddle explicitly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "jekyll-github-metadata"
 gem "jekyll-octicons"
 gem "jekyll-org", git: "https://github.com/eggcaker/jekyll-org.git"
 gem 'faraday-retry'
+gem 'fiddle'
 gem 'jekyll'
 gem 'wdm', '>= 0.2.0' if Gem.win_platform?
 gem 'word_wrap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,7 @@ GEM
     faraday-retry (2.3.2)
       faraday (~> 2.0)
     ffi (1.17.2-x64-mingw-ucrt)
+    fiddle (1.1.6)
     forwardable-extended (2.6.0)
     google-protobuf (4.32.0-x64-mingw-ucrt)
       bigdecimal
@@ -116,6 +117,7 @@ PLATFORMS
 DEPENDENCIES
   dotenv (~> 2.7)
   faraday-retry
+  fiddle
   jekyll
   jekyll-github-metadata
   jekyll-octicons


### PR DESCRIPTION
"C:/hostedtoolcache/windows/Ruby/3.4.1/x64/lib/ruby/3.4.0/win32/registry.rb:2:  warning: fiddle/import is found in fiddle, which will no longer be part  of the default gems starting from Ruby 3.5.0."